### PR TITLE
Adicionando CODEOWNERS ao github settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Designando Revisores de diretórios do repositório para designação automática ao criar Pull Requests
+
+* @thiagopac @rodolfoiannazzo @dawkk @LopeszD @andreo-san @jozimarSantos
+/docs/ @thiagopac @rodolfoiannazzo @dawkk @LopeszD @andreo-san @jozimarSantos
+/presentation/ @thiagopac @rodolfoiannazzo @dawkk @LopeszD @andreo-san @jozimarSantos
+/src/ @thiagopac @rodolfoiannazzo @dawkk @LopeszD @andreo-san @jozimarSantos


### PR DESCRIPTION
Adicionando diretório de settings do github (.github) e arquivo CODEOWNERS que especifica os diretórios do repositório e os responsáveis pela revisão, para designação automática na criação de Pull Requests